### PR TITLE
change slack auto update key

### DIFF
--- a/Slack/com.tinyspeck.slackmacgap.json
+++ b/Slack/com.tinyspeck.slackmacgap.json
@@ -7,9 +7,9 @@
         "remove_empty_properties": true
     },
     "properties": {
-        "SlackNoAutoUpdates": {
+        "AutoUpdate": {
             "title": "Disable Auto Updates",
-            "description": "(SlackNoAutoUpdates)-Disables Auto Updates",
+            "description": "(AutoUpdate)-Disables Auto Updates",
             "anyOf": [
                 {
                     "type": "null",


### PR DESCRIPTION
Slack changed the key associated with auto updates, PR is to update the schema to reflect that change.

Slack deprecation documentation (announcement date 4/22/24): https://slack.com/help/articles/4426294050451-Slack-feature-retirements#retired-features

Slack documentation referencing the new key: https://slack.com/help/articles/11906214948755-Manage-desktop-app-configurations#mac-2